### PR TITLE
NQN escape: remove only one \ and only when it's preceding emoji code

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,9 +4,9 @@ const { getCustomEmojiById } = findByProps('getCustomEmojiById');
 const { getLastSelectedGuildId } = findByProps('getLastSelectedGuildId');
 
 function handleEscapedEmojis(content) {
-    const messageAsArray = content.split("").filter(char => char != "\\");
+    const messageAsArray = content.replaceAll(/\\?(<a?:(\w+):(\d+)>)/ig,'$1');
 
-    return messageAsArray.join("");
+    return messageAsArray;
 }
 
 function extractNonUsableEmojis(messageString, size) {


### PR DESCRIPTION
Tested and working as intended so far. Hopefully this is good enough/I didn't miss anything.