### PR TITLE
Minor escape regex update

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,7 @@ const { getCustomEmojiById } = findByProps('getCustomEmojiById');
 const { getLastSelectedGuildId } = findByProps('getLastSelectedGuildId');
 
 function handleEscapedEmojis(content) {
-    return content.replaceAll(/\\?(<a?:(\w+):(\d+)>)/ig, '$1');
+    return content.replaceAll(/\\(<a?:(\w+):(\d+)>)/ig, '$1');
 }
 
 function extractNonUsableEmojis(messageString, size) {


### PR DESCRIPTION
No reason to match non-escaped emojis, function will just replace them with same thing unnecessarily.